### PR TITLE
finished != headersSent

### DIFF
--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -55,7 +55,7 @@ export default function withApollo<TCache = any>(
           appProps = await getInitialProps(appCtx);
         }
 
-        if (ctx.res && ctx.res.headersSent) {
+        if (ctx.res && (ctx.res.headersSent || ctx.res.finished)) {
           return {};
         }
 

--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -55,7 +55,7 @@ export default function withApollo<TCache = any>(
           appProps = await getInitialProps(appCtx);
         }
 
-        if (ctx.res && ctx.res.finished) {
+        if (ctx.res && ctx.res.headersSent) {
           return {};
         }
 


### PR DESCRIPTION
The headers might have been sent but the request isn't finished yet. I have been facing some error in production because of the difference.