### PR TITLE
Add IE11 support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es5",
     "module": "commonjs",
     "baseUrl": "./",
     "rootDir": "src",


### PR DESCRIPTION
https://nextjs.org/docs/faq
Looking at the above document, next.js supports ie11.
So I think better that next-with-apollo also supports this.

