### PR TITLE
Allow restoring cache without getDataFromTree

### DIFF
--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -91,9 +91,9 @@ export default function withApollo<TCache = any>(
             // getDataFromTree does not call componentWillUnmount
             // head side effect therefore need to be cleared manually
             Head.rewind();
-
-            apolloState.data = apollo.cache.extract();
           }
+
+          apolloState.data = apollo.cache.extract();
         }
 
         // To avoid calling initApollo() twice in the server we send the Apollo Client as a prop


### PR DESCRIPTION
While I do not use `getDataFromTree`, I do query inside `getInitialProps` using `ctx.apolloClient`. However, this the result of the query will not be restored in the client-side ApolloClient cache.

This PR allows it to also restore cache without `getDataFromTree`.