### PR TITLE
updat peer deps for react 17 and next 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "isomorphic-unfetch": "^3.0.0"
   },
   "peerDependencies": {
-    "next": "^9.0.0",
-    "react": "^16.6.0",
-    "react-dom": "^16.6.0"
+    "next": "^9.0.0 || ^10.0.0",
+    "react": "^16.6.0 || ^17.0.0",
+    "react-dom": "^16.6.0 || ^17.0.0"
   },
   "devDependencies": {
     "@apollo/react-hooks": "^3.0.1",


### PR DESCRIPTION
With npm 7, this package wont allow you to install if you are using react 17 and/or next.js 10