### PR TITLE
Remove Head.rewind usage for Next.js 11

### DIFF
--- a/src/withApollo.tsx
+++ b/src/withApollo.tsx
@@ -93,10 +93,6 @@ export default function withApollo<TCache = any>(
               }
             }
 
-            // getDataFromTree does not call componentWillUnmount
-            // head side effect therefore need to be cleared manually
-            Head.rewind();
-
             apolloState.data = apollo.cache.extract();
           }
         }


### PR DESCRIPTION
[Head.rewind has been removed](https://github.com/vercel/next.js/blob/canary/docs/upgrading.md#remove-headrewind) in Next.JS 11. 

The deletion of the line should fix [this issue.](https://github.com/lfades/next-with-apollo/issues/164)